### PR TITLE
minor updates for stack lts-11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ dist
 *.chs.h
 *_stub.h
 
+/.stack-work/

--- a/README.md
+++ b/README.md
@@ -12,11 +12,9 @@ This interface does not aim to cover all of HDF5, at least not right now.  If th
 Installation
 -------------
 
-First, you'll need to install the [low level bindings](https://github.com/mokus0/bindings-hdf5) - see that project's [README](https://github.com/mokus0/bindings-hdf5/blob/master/README.md) for instructions.  Once you've done that, this package can be installed using cabal:
+This package can be installed with stack:
 
-    git clone https://github.com/mokus0/hs-hdf5.git
-    cd hs-hdf5
-    cabal install
+    stack install
 
 Usage
 ------

--- a/hdf5.cabal
+++ b/hdf5.cabal
@@ -118,7 +118,7 @@ test-suite hdf5-test
   main-is:             Spec.hs
   build-depends:       base
                      , hspec >= 2.4.3 && < 2.5
-                     , QuickCheck >= 2.9.2 && < 2.10
+                     , QuickCheck >= 2.9.2 && < 2.12
                      , temporary >= 1.2.0.4 && < 1.3
                      , hdf5
                      , bytestring

--- a/src/Bindings/HDF5/Raw/H5I.hsc
+++ b/src/Bindings/HDF5/Raw/H5I.hsc
@@ -75,7 +75,7 @@ instance Show HId_t where
         ( showString "HId_t 0x"
         . showString
             [ intToDigit (fromIntegral digit)
-            | place <- [bitSize x - 4, bitSize x - 8 .. 0]
+            | place <- [finiteBitSize x - 4, finiteBitSize x - 8 .. 0]
             , let mask = 0xf `shiftL` place
             , let digit = ((x .&. mask) `shiftR` place) .&. 0xf
             ]

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-8.17
+resolver: lts-11.2
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -37,10 +37,6 @@ resolver: lts-8.17
 # will not be run. This is useful for tweaking upstream packages.
 packages:
 - '.'
-- location:
-    git: https://github.com/jwiegley/bindings-dsl
-    commit: fcd30e51d93efd8052ff2329cabe22ad0f7b1e31
-  extra-dep: true
 
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)


### PR DESCRIPTION
Mainly seeing if you have interest in maintaining this, or I should just use my own fork.  I'll probably be adding a few more things as I need them.  :+1: for switching to `combined-repo` too.  Also, it seems to build and so far work fine against hdf 1.10, so not sure if the 1.10.x branch is still relevant.

Now that bindings-dsl is in stackage, don't need to explicitly add the dep.

Cleanup one warning.